### PR TITLE
Add `xt` functions to coerce to PureScript Tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
 # purescript-tuples-native
 
 This library defines tuple data types that are represented under-the-hood as heterogeneous arrays to JavaScript - useful for
-foreign interfaces:
+foreign interfaces. A set of `xt` functions are exposed to translate these native Tuples into Purescript pairs
+or Nested tuples. So for example:
+
+```purescript
+-- Main.purs
+import Data.Tuple.Native (T2, xt)
+import Data.Tuple (Tuple)
+
+foreign import lenTupleImpl :: String -> T2 String Int
+
+lenTuple :: String -> Tuple String Int
+lenTuple s = xt $ lenTupleImpl s
+```
+
+Could let you wrap this Javascript function
+```javascript
+"use strict";
+function lenTuple (string) {
+    return [string, string.length]
+}
+exports.lenTupleImpl = lenTuple
+```
+
+You can also extract indidual elements directly from the Native tuple using `prj`.
 
 ```purescript
 import Data.Tuple.Native (T3, t3, prj)

--- a/src/Data/Tuple/Native.purs
+++ b/src/Data/Tuple/Native.purs
@@ -4,6 +4,8 @@ module Data.Tuple.Native
   ( TupleN
   , T2, T3, T4, T5, T6, T7, T8, T9
   , t2, t3, t4, t5, t6, t7, t8, t9
+  , xt
+  , xt2, xt3, xt4, xt5, xt6, xt7, xt8, xt9
   , prj
   , class TupleSize, class ShowNat
   ) where
@@ -13,9 +15,39 @@ import Data.Typelevel.Num
   ( D0, D1, D2, D3, D4, D5, D6, D7, D8, D9, class Lt, class Nat, toInt
   , d0, d1, d2, d3, d4, d5, d6, d7, d8)
 import Data.Generic.Rep (class Generic, Constructor (..), Argument (..), Product (..))
+import Data.Tuple as DT
+import Data.Tuple.Nested as DTN
 import Type.RowList (Cons, Nil, kind RowList, class ListToRow)
 import Prim.Row (class Cons)
 
+-- | Safely coerce a `TupleN` pair into a PureScript Tuple
+xt :: forall a b. T2 a b -> DT.Tuple a b
+xt t = DT.Tuple (prj d0 t) (prj d1 t)
+
+-- | Safely coerce a `TupleN` pair into a PureScript Nested Tuple
+xt2 :: forall a b. T2 a b -> DTN.Tuple2 a b
+xt2 t = DTN.tuple2 (prj d0 t) (prj d1 t)
+
+xt3 :: forall a b c. T3 a b c -> DTN.Tuple3 a b c
+xt3 t = DTN.tuple3 (prj d0 t) (prj d1 t) (prj d2 t)
+
+xt4 :: forall a b c d. T4 a b c d -> DTN.Tuple4 a b c d
+xt4 t = DTN.tuple4 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t)
+
+xt5 :: forall a b c d e. T5 a b c d e -> DTN.Tuple5 a b c d e
+xt5 t = DTN.tuple5 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t) (prj d4 t)
+
+xt6 :: forall a b c d e f. T6 a b c d e f -> DTN.Tuple6 a b c d e f
+xt6 t = DTN.tuple6 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t) (prj d4 t) (prj d5 t)
+
+xt7 :: forall a b c d e f g. T7 a b c d e f g -> DTN.Tuple7 a b c d e f g
+xt7 t = DTN.tuple7 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t) (prj d4 t) (prj d5 t) (prj d6 t)
+
+xt8 :: forall a b c d e f g h. T8 a b c d e f g h -> DTN.Tuple8 a b c d e f g h
+xt8 t = DTN.tuple8 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t) (prj d4 t) (prj d5 t) (prj d6 t) (prj d7 t)
+
+xt9 :: forall a b c d e f g h i. T9 a b c d e f g h i -> DTN.Tuple9 a b c d e f g h i
+xt9 t = DTN.tuple9 (prj d0 t) (prj d1 t) (prj d2 t) (prj d3 t) (prj d4 t) (prj d5 t) (prj d6 t) (prj d7 t) (prj d8 t)
 
 foreign import prjImpl :: forall t a. Int -> TupleN t -> a
 

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function lenTuple (string) {
+    return [string, string.length]
+}
+
+exports.lenTupleImpl = lenTuple

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,18 @@
 module Test.Main where
 
-import Data.Tuple.Native (T3, prj, t3)
+import Data.Tuple.Native (T2, T3, prj, t3, xt, xt3)
+import Data.Tuple (Tuple)
+import Data.Tuple.Nested (Tuple3)
 import Data.Typelevel.Num (d0, d1, d2)
 
 import Prelude (Unit, discard, ($))
 import Effect (Effect)
 import Effect.Console (logShow)
+
+foreign import lenTupleImpl :: String -> T2 String Int
+
+lenTuple :: String -> Tuple String Int
+lenTuple s = xt $ lenTupleImpl s
 
 main :: Effect Unit
 main = do
@@ -15,3 +22,12 @@ main = do
   logShow $ prj d0 x
   logShow $ prj d1 x
   logShow $ prj d2 x
+
+  let t :: Tuple3 Int Int Int
+      t = xt3 x
+  logShow $ t
+
+  -- test foreign import
+  let l :: Tuple String Int
+      l = lenTuple "Testing"
+  logShow l


### PR DESCRIPTION
These functions may be more convenient to work with than raw `prj`
calls.

    `xt` converts to a Data.Tuple pair.
    `xtN` converts to a Data.Tuple.Nested structure.

An example usage is provided in the README and test.

(I'm on #purescript Slack, and have pinged you there. Happy to discuss if I'm missing a simpler way to do this / this isn't the approach you want to take, etc. and I can help rework!)